### PR TITLE
Disable pushing a 'latest' tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,8 @@ jobs:
         DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
         DOCKER_REGISTRY: "quay.io"
+        # Disable pushing a 'latest' tag, as this often just causes confusion
+        LATEST_TAG_OFF: true
 
         # Uncomment and modify the following line with your image name, otherwise no push will happen
         # IMAGE_NAME: "<quay-username>/<repository-name>"


### PR DESCRIPTION
This causes more problems than it solves, as it can confuse
users about which image they are actually running