### PR TITLE
Set default to python 3.10

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,5 +7,8 @@ dependencies:
   - jupyter_contrib_nbextensions==0.5.1
   # Required until https://github.com/jupyterhub/repo2docker/pull/1196 is merged
   - jupyterhub-singleuser>=3.0,<4.0
+  # Set default python version to 3.10 - repo2docker sets it to 3.7 instead by default,
+  # which can limit us to older package versions
+  - python=3.10
   # Add other packages here
   # -


### PR DESCRIPTION
Without this, conda can arbitrarily pin other libraries as well to older
versions of packages, which can be quite confusing